### PR TITLE
cleanup gemspec

### DIFF
--- a/minitest-line.gemspec
+++ b/minitest-line.gemspec
@@ -1,18 +1,9 @@
-# -*- encoding: utf-8 -*-
-
-Gem::Specification.new do |s|
-  s.name     = "minitest-line"
-  s.version  = "0.6.0"
-  s.date     = "2014-03-25"
-  s.summary  = "Focused tests for Minitest"
+Gem::Specification.new "minitest-line", "0.6.0" do |s|
+  s.description = s.summary  = "Focused tests for Minitest"
   s.email    = "judofyr@gmail.com"
   s.homepage = "https://github.com/judofyr/minitest-line"
   s.authors  = ['Magnus Holm']
-  
-  s.description = s.summary
-  
-  s.files         = Dir['{test,lib}/**/*']
-  s.test_files    = Dir['test/**/*']
-
+  s.license  = "MIT"
+  s.files    = Dir['lib/**/*.rb']
   s.add_runtime_dependency('minitest', '~> 5.0')
 end


### PR DESCRIPTION
- ship less files / do not ship tmp files by accident
- add license
- remove unnecessary date

@judofyr also not sure why rubygems has 0.6.1 and this is 0.6.0
