### PR TITLE
run describe blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,14 @@
 
 A Minitest 5 plugin for running focused tests.
 
+```Bash
+gem install minitest-line
+ruby test/my_file -l 5
 ```
-$ gem install minitest-line
-$ ruby test/my_file -l 5
+
+If you want to be able to run describe block by line number add
+```Ruby
+require 'minitest/line/describe_track'
 ```
 
 ## Acknowledgments

--- a/lib/minitest/line/describe_track.rb
+++ b/lib/minitest/line/describe_track.rb
@@ -1,0 +1,13 @@
+module Minitest
+  module Line
+    module DescribeTrack
+      def describe(*args, &block)
+        klass = super
+        klass.instance_variable_set(:@minitest_line_caller, caller[0..5])
+        klass
+      end
+    end
+  end
+end
+
+Object.send(:include, Minitest::Line::DescribeTrack)


### PR DESCRIPTION
@judofyr here we go :)

It's a bit hacky, but it's opt-in ...
also:
- moved code into it's own namespace
- extracted a few methods
- possible to run a line after the describe and it runs up to the describe
- possible to run describe via a helper methods (we use a bunch of things like "as_a_admin do" etc)
