### PR TITLE
target file is always the file passed to ruby

### DIFF
--- a/lib/minitest/line_plugin.rb
+++ b/lib/minitest/line_plugin.rb
@@ -4,21 +4,11 @@ module Minitest
   module Line
     class << self
       def tests_with_lines
-        target_file = target_file()
+        target_file = $0
         methods_with_lines(target_file).concat describes_with_lines(target_file)
       end
 
       private
-
-      def target_file
-        runnables.each do |r|
-          r.runnable_methods.each do |m|
-            file, line = r.instance_method(m).source_location
-            return file if file
-          end
-        end
-        nil
-      end
 
       def methods_with_lines(target_file)
         runnables.flat_map do |runnable|

--- a/test/cases/helper.rb
+++ b/test/cases/helper.rb
@@ -1,0 +1,5 @@
+def create_test
+  it "create" do
+    1.must_equal 1
+  end
+end

--- a/test/cases/test_with_foreign_method.rb
+++ b/test/cases/test_with_foreign_method.rb
@@ -1,0 +1,14 @@
+require_relative 'helper'
+require 'minitest/autorun'
+
+describe '' do
+  create_test
+
+  it "works" do
+    puts "WORKS"
+  end
+
+  it "fails" do
+    puts "FAILS"
+  end
+end

--- a/test/test_line.rb
+++ b/test/test_line.rb
@@ -177,5 +177,19 @@ describe "Minitest::Line" do
     result.must_include "TEST-A"
     result.wont_include "TEST-B"
   end
+
+  describe "when first test is a foreign test" do
+    it "can run tests by line with absolute path" do
+      result = sh("ruby #{Bundler.root}/test/cases/test_with_foreign_method.rb -l 7")
+      result.must_include "WORKS"
+      result.wont_include "FAILS"
+    end
+
+    it "can run tests by line with relative path" do
+      result = sh("ruby test/cases/test_with_foreign_method.rb -l 7")
+      result.must_include "WORKS"
+      result.wont_include "FAILS"
+    end
+  end
 end
 


### PR DESCRIPTION
with a test that defines the first test using a helper we try to find tests in the wrong file.
```
describe "xxx" do
  some_helper_method

  it "xxx" do
  end
end
```

but since the invocation is always ruby xxx.rb -l 123 we can just grab $0 and use that as the file you are interested in -> much simpler and not more false matches

@judofyr