### PR TITLE
Improve test file guessing

### DIFF
--- a/lib/minitest/line_plugin.rb
+++ b/lib/minitest/line_plugin.rb
@@ -5,6 +5,9 @@ module Minitest
     class << self
       def tests_with_lines
         target_file = $0
+        if target_file =~ /(?:^|\s|\/)rake\s+test\s+(\S+)/
+          target_file = $1
+        end
         methods_with_lines(target_file).concat describes_with_lines(target_file)
       end
 
@@ -15,7 +18,7 @@ module Minitest
           rname = runnable.name
           runnable.runnable_methods.map do |name|
             file, line = runnable.instance_method(name).source_location
-            next unless file == target_file
+            next unless File.absolute_path(file) == File.absolute_path(target_file)
             test_name = (rname ? "#{rname}##{name}" : name)
             [test_name, line]
           end

--- a/lib/minitest/line_plugin.rb
+++ b/lib/minitest/line_plugin.rb
@@ -3,7 +3,7 @@ require 'pathname'
 module Minitest
   module Line
     class << self
-      def tests_with_linesfile(file = nil)
+      def tests_with_lines(file = nil)
         if file
           target_file = file
         else

--- a/lib/minitest/line_plugin.rb
+++ b/lib/minitest/line_plugin.rb
@@ -3,10 +3,14 @@ require 'pathname'
 module Minitest
   module Line
     class << self
-      def tests_with_lines
-        target_file = $0
-        if target_file =~ /(?:^|\s|\/)rake\s+test\s+(\S+)/
-          target_file = $1
+      def tests_with_linesfile(file = nil)
+        if file
+          target_file = file
+        else
+          target_file = $0
+          if target_file =~ /(?:^|\s|\/)rake\s+test\s+(\S+)/
+            target_file = $1
+          end
         end
         methods_with_lines(target_file).concat describes_with_lines(target_file)
       end
@@ -51,7 +55,8 @@ module Minitest
       return
     end
 
-    tests = Minitest::Line.tests_with_lines
+    tests = Minitest::Line.tests_with_lines(options[:file])
+
 
     filter, _ = tests.sort_by { |n, l| -l }.detect { |n, l| exp_line >= l }
 


### PR DESCRIPTION
I've found that launching with spring binstub or plain rake command is not working, so
I've improve test file guessing.

So, now launching single test given by line number is OK (with corresponding [fixes in minitest](https://github.com/seattlerb/minitest/pull/687)) with three popular launching commands:
`./bin/rake test test/some_test.rb -l 42`
`rake test test/some_test.rb -l 42`
`ruby -Itest test/some_test.rb -l 42`

@judofyr review pls!:)